### PR TITLE
"東京大学大気海洋研究所オープンサイエンス推進室" を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,4 +600,4 @@
 
 ---
 
-_Contributors_: [@ozekik](https://github.com/ozekik/)
+_Contributors_: [@ozekik](https://github.com/ozekik/), [@Rindrics](https://github.com/Rindrics)

--- a/README.md
+++ b/README.md
@@ -520,6 +520,13 @@
 
 - [日本中央バス](https://ncb.jp/route/GTFS.htm) (群馬県) - バス路線・ダイヤデータ
 
+### 大学
+
+- [東京大学大気海洋研究所オープンサイエンス推進室](https://opensci.aori.u-tokyo.ac.jp/index.html)
+    - [研究船観測データベース](https://opensci.aori.u-tokyo.ac.jp/cruise.html)
+    - [大槌湾観測データベース](https://opensci.aori.u-tokyo.ac.jp/otsuchi.html)
+    - [環境DNAマップ](https://opensci.aori.u-tokyo.ac.jp/oeDNAmap.html)
+
 ## 検索
 
 - [データカタログ横断検索システム](https://search.ckan.jp/) (NII)

--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@
 #### 神奈川県
 
 - [神奈川県オープンデータサイト](https://www.pref.kanagawa.jp/dst/index.html)
-- [神奈川県警察オープンデータサイト](https://www.police.pref.kanagawa.jp/mes/mesd0145.htm) (神奈川県警察)
 
 ##### 横浜市
 


### PR DESCRIPTION
とりまとめありがとうございます。

東京大学大気海洋研究所が、収集した研究データの一部を公開してくれていたのでお知らせします。

出典の明記は必要ですが、利用、再配布、再利用の制限がないのでオープンデータとしてよいのではないかと思いました。

ご検討ください。