### PR TITLE
企業セクションに JCCDB(日本建設費オープンデータベース)を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,4 +626,4 @@
 
 ---
 
-_Contributors_: [@ozekik](https://github.com/ozekik/), [@Rindrics](https://github.com/Rindrics), [@maekawa-mugi](https://github.com/maekawa-mugi), [@ajtgjmdjp](https://github.com/ajtgjmdjp), [@J-Miyamae](https://github.com/J-Miyamae), [@yoshiblog-space](https://github.com/yoshiblog-space), [@Shirabe-dev-sys](https://github.com/Shirabe-dev-sys), [@bunsato](https://github.com/bunsato), [@zurekei](https://github.com/zurekei)
+_Contributors_: [@ozekik](https://github.com/ozekik/), [@Rindrics](https://github.com/Rindrics), [@maekawa-mugi](https://github.com/maekawa-mugi), [@ajtgjmdjp](https://github.com/ajtgjmdjp), [@J-Miyamae](https://github.com/J-Miyamae), [@yoshiblog-space](https://github.com/yoshiblog-space), [@Shirabe-dev-sys](https://github.com/Shirabe-dev-sys), [@bunsato](https://github.com/bunsato), [@zurekei](https://github.com/zurekei), [@ogasurfproject-jpg](https://github.com/ogasurfproject-jpg)

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@
 - [PLATEAU (プラトー)](https://www.mlit.go.jp/plateau/) - 国土交通省が主導する、日本全国の3D都市モデルの整備・オープンデータ化プロジェクト
 - [G空間情報センター](https://front.geospatial.jp/) (AIGID)
 
-##### 不動産
+##### 不動産・建設
 
 - [不動産情報ライブラリ](https://www.reinfolib.mlit.go.jp/) (国土交通省) - 不動産価格（取引価格・成約価格）情報、地価情報などの不動産関連データのダウンロード、APIも提供 (旧 土地総合情報システム)
+- [JCCDB 日本建設費オープンデータベース 品目データ](https://github.com/ogasurfproject-jpg/japan-construction-cost-database/blob/main/README.ja.md) (The HORIZ音s株式会社) - メーカーWebサイトなどから独自に収集した建設・リフォーム工事資材の品目名・カテゴリ・単位のデータセット
 
 ##### 大気・気象
 
@@ -536,7 +537,6 @@
 ### 企業
 
 - [日本中央バス](https://ncb.jp/route/GTFS.htm) (群馬県) - バス路線・ダイヤデータ
-- [JCCDB 日本建設費オープンデータベース](https://github.com/ogasurfproject-jpg/japan-construction-cost-database) - 建設・リフォーム工事の品目65,729件・63カテゴリ(品目名・カテゴリ・単位)を収録するオープンデータセット。DOI・ORCID付き、AI建設費診断サービスの一次データとして稼働中 (CC BY 4.0、The HORIZ音s株式会社)
 
 ### 大学
 

--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@
 ### 企業
 
 - [日本中央バス](https://ncb.jp/route/GTFS.htm) (群馬県) - バス路線・ダイヤデータ
+- [JCCDB 日本建設費オープンデータベース](https://github.com/ogasurfproject-jpg/japan-construction-cost-database) - 建設・リフォーム工事の品目65,729件・63カテゴリ(品目名・カテゴリ・単位)を収録するオープンデータセット。DOI・ORCID付き、AI建設費診断サービスの一次データとして稼働中 (CC BY 4.0、The HORIZ音s株式会社)
 
 ### 大学
 


### PR DESCRIPTION
企業セクションへの追加提案です。

JCCDB は建設・リフォーム工事の品目 65,729 件・63 カテゴリ(品目名・カテゴリ・単位)を収録するオープンデータセットです(CC BY 4.0)。価格情報は含みません。

- 学術公開: Zenodo DOI https://doi.org/10.5281/zenodo.20019573 / engrXiv https://doi.org/10.31224/7007
- 著者 ORCID: https://orcid.org/0009-0000-9180-903X
- 機械可読ミラー: Hugging Face https://huggingface.co/datasets/ogasurfproject/jccdb
- 利用実績: 建設見積検証サービス HORIZON SHIELD の一次データとして MCP/A2A および ChatGPT プラグインで稼働中

リンク切れ・記載修正等あればご指摘ください。