### PR TITLE
ダッシュボード/アプリケーションに「医療さがし」を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@
 - [まちケア](https://machicare.jp/) (データクレイドル)
 - [LocalGov.jp](https://localgov.jp/) (個人運営) - J-Grantsなどを元データとした、中央省庁や全国市町村の補助金・助成金を統合検索できるポータル
 - [zurekei (ズレ計)](https://zurekei.org/) (個人運営) - 政府・公的機関の経済見通しと実績を、公表のたび記録・照合する計器サイト
+- [医療さがし](https://iryosagashi.online/) (個人運営) - 厚生労働省「医療情報ネット」のオープンデータ全197,967件を正規化し、市区町村・診療科・診療時間で検索できる医療機関検索サイト。1kmメッシュ人口と突き合わせた[医療アクセス圏外人口の推計](https://iryosagashi.online/stats/access/)や集計CSVも公開（[GitHub](https://github.com/shiorisuimoku-netizen/iryosagashi-opendata)）
 
 ## サービス/API
 


### PR DESCRIPTION
「ダッシュボード/アプリケーション/ポータル」セクションに、個人運営の医療機関検索サイト「医療さがし」の追加を提案します。

- サイト: https://iryosagashi.online/
- 元データ: 厚生労働省「医療情報ネット」のオープンデータ（全197,967施設）を全件正規化。国土数値情報の1kmメッシュ人口・住民基本台帳人口も併用しています
- 市区町村・診療科・診療時間（今開いている等）での検索に加え、施設座標とメッシュ人口を突き合わせた「医療アクセス圏外人口」の市区町村別推計を公開しています: https://iryosagashi.online/stats/access/
- 集計スクリプトとCSVはMITライセンスでGitHubにも置いています: https://github.com/shiorisuimoku-netizen/iryosagashi-opendata
- 出典・データ時点（2025年12月1日）・「国が最新性を保証するものではない」旨は全ページに明記しています

記載フォーマットは既存の個人運営サイト（LocalGov.jp / zurekei）に合わせました。位置や表現の修正はご自由にどうぞ。